### PR TITLE
hardening SSL + HEADER

### DIFF
--- a/templates/haproxy.cfg.tmpl
+++ b/templates/haproxy.cfg.tmpl
@@ -3,7 +3,8 @@ global
   log /dev/log local0 notice
   maxconn 4096
   tune.ssl.default-dh-param 2048
-  ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
+  ssl-default-bind-options no-sslv3 no-tls-tickets force-tlsv12
+  ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:!CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
 
 defaults
   log global
@@ -25,13 +26,17 @@ frontend http-in
 {{ range $host, $container := groupBy $ "Env.AUTOCONFIG_HOST" }}
   redirect location https://{{ $host }}/mail/config-v1.1.xml code 301 if { hdr_beg(host) -i autoconfig }
 {{end}}
-  redirect scheme https code 301
+  redirect scheme https code 301 ! { ssl_fc }
 
 frontend https-in
 mode http
-  bind *:443 ssl no-sslv3 crt /etc/haproxy/certs
+  bind *:443 ssl crt /etc/haproxy/certs
   reqadd X-Forwarded-Proto:\ https
-  rspadd  Strict-Transport-Security:\ max-age=15768000
+  rspadd X-Frame-Options:\ SAMEORIGIN # OR DENY
+  rspadd X-XSS-Protection:\ 1;\ mode=block
+  rspadd X-Content-Type-Options:\ nosniff
+  rspadd Strict-Transport-Security:\ max-age=15768000
+  rspadd Referrer-Policy:\ no-referrer-when-downgrade
 
   use_backend letsencrypt-web if { path_beg /.well-known/acme }
 {{ range $host, $containers := groupBy $ "Env.LIBRESH_WEBHOOK_HOST" }}

--- a/templates/haproxy.cfg.tmpl
+++ b/templates/haproxy.cfg.tmpl
@@ -26,7 +26,7 @@ frontend http-in
 {{ range $host, $container := groupBy $ "Env.AUTOCONFIG_HOST" }}
   redirect location https://{{ $host }}/mail/config-v1.1.xml code 301 if { hdr_beg(host) -i autoconfig }
 {{end}}
-  redirect scheme https code 301 ! { ssl_fc }
+  redirect scheme https code 301 if ! { ssl_fc }
 
 frontend https-in
 mode http


### PR DESCRIPTION
+ global option == no-sslv3 no-tls-tickets force-tlsv12
- CAMELIA CIPHER == on the way to be NIST & HIPAA Compliant
+ redirect only if not already SSL

+ Hardening HEADER with:
++ X-Frame-Options:\ SAMEORIGIN # OR DENY is another option
++ X-XSS-Protection
++ X-Content-Type-Options == nosniff
++ Referrer-Policy == no-referrer-when-downgrade

which bring the security headers grade from E to B
tested with https://securityheaders.io

NOTE:
Public-Key-Pins is more or less a DEAD project (https://blog.qualys.com/ssllabs/2016/09/06/is-http-public-key-pinning-dead)
Content-Security-Policy is tricky to make it GENERAL